### PR TITLE
Implement Property-System - a Generic way for storing mutable+serializable values

### DIFF
--- a/src/main/java/com/direwolf20/core/DireCore20.java
+++ b/src/main/java/com/direwolf20/core/DireCore20.java
@@ -1,5 +1,6 @@
 package com.direwolf20.core;
 
+import com.direwolf20.core.capability.PropertyContainerCapability;
 import com.direwolf20.core.capability.TraitContainerCapability;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -19,5 +20,6 @@ public final class DireCore20 {
 
     private void setup(final FMLCommonSetupEvent event) {
         TraitContainerCapability.register();
+        PropertyContainerCapability.register();
     }
 }

--- a/src/main/java/com/direwolf20/core/capability/PropertyContainerCapability.java
+++ b/src/main/java/com/direwolf20/core/capability/PropertyContainerCapability.java
@@ -1,0 +1,37 @@
+package com.direwolf20.core.capability;
+
+import com.direwolf20.core.DireCore20;
+import com.direwolf20.core.properties.IPropertyContainer;
+import com.direwolf20.core.properties.PropertyContainer;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.INBT;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.Capability.IStorage;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+
+import javax.annotation.Nullable;
+
+public enum PropertyContainerCapability {
+    ;
+    @CapabilityInject(IPropertyContainer.class)
+    public static Capability<IPropertyContainer> PROPERTY_CONTAINER_CAPABILITY = null;
+
+    public static void register() {
+        DireCore20.LOG.debug("Registering Property Container Capability");
+        CapabilityManager.INSTANCE.register(IPropertyContainer.class, new IStorage<IPropertyContainer>() {
+            @Nullable
+            @Override
+            public INBT writeNBT(Capability<IPropertyContainer> capability, IPropertyContainer instance, Direction side) {
+                return instance.serializeNBT();
+            }
+
+            @Override
+            public void readNBT(Capability<IPropertyContainer> capability, IPropertyContainer instance, Direction side, INBT nbt) {
+                instance.deserializeNBT((CompoundNBT)nbt);
+            }
+        }, () -> PropertyContainer.builder().build());
+        DireCore20.LOG.debug("Registered Property Container Capability");
+    }
+}

--- a/src/main/java/com/direwolf20/core/properties/IPropertyContainer.java
+++ b/src/main/java/com/direwolf20/core/properties/IPropertyContainer.java
@@ -1,0 +1,15 @@
+package com.direwolf20.core.properties;
+
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraftforge.common.util.INBTSerializable;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface IPropertyContainer extends INBTSerializable<CompoundNBT> {
+    <T> Optional<T> getProperty(Property<T> property);
+
+    <T> boolean setProperty(Property<T> property, T value);
+
+    Set<Property<?>> listProperties();
+}

--- a/src/main/java/com/direwolf20/core/properties/IPropertyContainer.java
+++ b/src/main/java/com/direwolf20/core/properties/IPropertyContainer.java
@@ -6,6 +6,21 @@ import net.minecraftforge.common.util.INBTSerializable;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * A serializable container handling {@link Property Properties}.
+ * <p>
+ * Retrieving the value for a specific {@link Property} can be done via {@link #getProperty(Property)} and it can be set via
+ * {@link #setProperty(Property, Object)}. Notice that it is not possible to add new Properties to the container, after it has been constructed.
+ * This class intentionally does not function as a generic container for attaching mutable values to
+ * {@link net.minecraftforge.common.capabilities.ICapabilityProvider CapProviders}, but instead is meant as a type safe container
+ * for the {@link net.minecraftforge.common.capabilities.ICapabilityProvider Providers} themselves. A Provider can limit the scope of access for
+ * Properties by limiting the access to the {@link Property} key. If a mechanism for limiting only mutation access is needed, we may add a
+ * "MutableProperty" class, which wraps or extends the original Property, and use that as the key for {@link #setProperty(Property, Object)}.
+ * <p>
+ * Serialisation will write the values of <b>all</b> Properties into the resulting {@link CompoundNBT}, keyed by {@link Property#getName()}.
+ * This results in all {@link Property Properties} within one container being forced to have unique names! It is up to the implementor
+ * of the Property and the user of the container to ensure that migration stays possible...
+ */
 public interface IPropertyContainer extends INBTSerializable<CompoundNBT> {
     <T> Optional<T> getProperty(Property<T> property);
 

--- a/src/main/java/com/direwolf20/core/properties/IPropertyContainer.java
+++ b/src/main/java/com/direwolf20/core/properties/IPropertyContainer.java
@@ -10,21 +10,25 @@ import java.util.Set;
  * A serializable container handling {@link Property Properties}.
  * <p>
  * Retrieving the value for a specific {@link Property} can be done via {@link #getProperty(Property)} and it can be set via
- * {@link #setProperty(Property, Object)}. Notice that it is not possible to add new Properties to the container, after it has been constructed.
+ * {@link #setProperty(MutableProperty, Object)}. Notice that it is not possible to add new Properties to the container, after it has been constructed.
  * This class intentionally does not function as a generic container for attaching mutable values to
  * {@link net.minecraftforge.common.capabilities.ICapabilityProvider CapProviders}, but instead is meant as a type safe container
  * for the {@link net.minecraftforge.common.capabilities.ICapabilityProvider Providers} themselves. A Provider can limit the scope of access for
- * Properties by limiting the access to the {@link Property} key. If a mechanism for limiting only mutation access is needed, we may add a
- * "MutableProperty" class, which wraps or extends the original Property, and use that as the key for {@link #setProperty(Property, Object)}.
+ * Properties by limiting the access to the {@link Property} key. In order to give even more fine-grained access, one may restrict access
+ * to the {@link MutableProperty}, but give free access to the {@link Property} - which simulates a read-only Property to the public!
  * <p>
  * Serialisation will write the values of <b>all</b> Properties into the resulting {@link CompoundNBT}, keyed by {@link Property#getName()}.
  * This results in all {@link Property Properties} within one container being forced to have unique names! It is up to the implementor
  * of the Property and the user of the container to ensure that migration stays possible...
  */
 public interface IPropertyContainer extends INBTSerializable<CompoundNBT> {
+    default <T> Optional<T> getProperty(MutableProperty<T> property) {
+        return getProperty(property.getProperty());
+    }
+
     <T> Optional<T> getProperty(Property<T> property);
 
-    <T> boolean setProperty(Property<T> property, T value);
+    <T> boolean setProperty(MutableProperty<T> property, T value);
 
     Set<Property<?>> listProperties();
 }

--- a/src/main/java/com/direwolf20/core/properties/MutableProperty.java
+++ b/src/main/java/com/direwolf20/core/properties/MutableProperty.java
@@ -8,11 +8,11 @@ import net.minecraft.nbt.INBT;
  * @param <T>
  */
 public final class MutableProperty<T> {
-    private final Property<T> delegate;
-
     MutableProperty(Property<T> delegate) {
         this.delegate = delegate;
     }
+
+    private final Property<T> delegate;
 
     public T cast(Object value) {
         return delegate.cast(value);

--- a/src/main/java/com/direwolf20/core/properties/MutableProperty.java
+++ b/src/main/java/com/direwolf20/core/properties/MutableProperty.java
@@ -1,0 +1,47 @@
+package com.direwolf20.core.properties;
+
+import com.google.common.base.MoreObjects;
+import net.minecraft.nbt.INBT;
+
+/**
+ * A wrapper around {@link Property} to allow for
+ * @param <T>
+ */
+public final class MutableProperty<T> {
+    private final Property<T> delegate;
+
+    MutableProperty(Property<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    public T cast(Object value) {
+        return delegate.cast(value);
+    }
+
+    public String getName() {
+        return delegate.getName();
+    }
+
+    public INBT serializeValue(Object value) {
+        return delegate.serializeValue(value);
+    }
+
+    public INBT serialize(T value) {
+        return delegate.serialize(value);
+    }
+
+    public T deserialize(INBT serialized) {
+        return delegate.deserialize(serialized);
+    }
+
+    public Property<T> getProperty() {
+        return delegate;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("property", delegate)
+                .toString();
+    }
+}

--- a/src/main/java/com/direwolf20/core/properties/Property.java
+++ b/src/main/java/com/direwolf20/core/properties/Property.java
@@ -12,8 +12,8 @@ import java.util.function.Function;
 
 /**
  * A Property is the key to some mutable and serializable value within an {@link IPropertyContainer}. The value may be retrieved via
- * {@link IPropertyContainer#getProperty(Property)} or set via {@link IPropertyContainer#setProperty(Property, Object)} in a type safe way.
- * The latter is achieved, by casting the results to they type passed into the builder.
+ * {@link IPropertyContainer#getProperty(Property)} or set via {@link IPropertyContainer#setProperty(MutableProperty, Object)} (if a write-access Property
+ * has been obtained) in a type safe way. The latter is achieved, by casting the results to they type passed into the builder.
  * <p>
  * Notice that as of this writing a Property must be capable of serializing and deserializing it's values, as well as having a
  * {@link IPropertyContainer container} wide unique name.
@@ -147,6 +147,25 @@ public final class Property<T> {
 
         public Property<T> build() {
             return new Property<>(type, name, serializer, deserializer);
+        }
+
+        public MutableProperty<T> buildMutable(ResourceLocation resourceLocation) {
+            name(resourceLocation);
+            return buildMutable();
+        }
+
+        public MutableProperty<T> buildMutable(String modid, String path) {
+            name(modid, path);
+            return buildMutable();
+        }
+
+        public MutableProperty<T> buildMutable(String name) {
+            name(name);
+            return buildMutable();
+        }
+
+        public MutableProperty<T> buildMutable() {
+            return new MutableProperty<>(build());
         }
     }
 }

--- a/src/main/java/com/direwolf20/core/properties/Property.java
+++ b/src/main/java/com/direwolf20/core/properties/Property.java
@@ -10,19 +10,44 @@ import net.minecraft.util.ResourceLocation;
 import java.util.Objects;
 import java.util.function.Function;
 
+/**
+ * A Property is the key to some mutable and serializable value within an {@link IPropertyContainer}. The value may be retrieved via
+ * {@link IPropertyContainer#getProperty(Property)} or set via {@link IPropertyContainer#setProperty(Property, Object)} in a type safe way.
+ * The latter is achieved, by casting the results to they type passed into the builder.
+ * <p>
+ * Notice that as of this writing a Property must be capable of serializing and deserializing it's values, as well as having a
+ * {@link IPropertyContainer container} wide unique name.
+ * @see IPropertyContainer
+ * @param <T> The type of the values represented by this Property
+ */
 public final class Property<T> {
+    /**
+     *
+     * @param type The class of the values represented by the resulting {@link Property}
+     * @param <T> The type of the values represented by the resulting {@link Property}
+     * @return a new {@link Builder}
+     */
     public static <T> Builder<T> builder(Class<T> type) {
         return new Builder<>(type);
     }
 
+    /**
+     * @return A Builder pre-configured to create serializable Integer Properties. Only the name is missing.
+     */
     public static Builder<Integer> intBuilder() {
         return builder(Integer.class).serializer(IntNBT::valueOf).deserializer(inbt -> ((IntNBT) inbt).getInt());
     }
 
+    /**
+     * @return A Builder pre-configured to create serializable Boolean Properties. Only the name is missing.
+     */
     public static Builder<Boolean> booleanBuilder() {
         return builder(Boolean.class).serializer(ByteNBT::valueOf).deserializer(inbt -> ((ByteNBT) inbt).getByte() != 0);
     }
 
+    /**
+     * @return A Builder pre-configured to create serializable Float Properties. Only the name is missing.
+     */
     public static Builder<Float> floatBuilder() {
         return builder(Float.class).serializer(FloatNBT::valueOf).deserializer(inbt -> ((FloatNBT) inbt).getFloat());
     }
@@ -35,8 +60,8 @@ public final class Property<T> {
     private Property(Class<T> type, String name, Function<T, INBT> serializer, Function<INBT, T> deserializer) {
         this.type = Objects.requireNonNull(type, "Cannot have a property without a type!");
         this.name = Objects.requireNonNull(name, "Cannot have a property without a name!");
-        this.serializer = Objects.requireNonNull(serializer);
-        this.deserializer = Objects.requireNonNull(deserializer);
+        this.serializer = Objects.requireNonNull(serializer, "Cannot have a property without a serializer!");
+        this.deserializer = Objects.requireNonNull(deserializer, "Cannot have a property without a deserializer!");
     }
 
     T cast(Object value) {
@@ -67,6 +92,11 @@ public final class Property<T> {
                 .toString();
     }
 
+    /**
+     * A simple builder to allow chaining of the required values, instead of being required to pass values to a lengthy factory Method.
+     * It also offers some utility overloads.
+     * @param <T> The type of the resulting {@link Property}
+     */
     public static final class Builder<T> {
         private Class<T> type;
         private String name;

--- a/src/main/java/com/direwolf20/core/properties/Property.java
+++ b/src/main/java/com/direwolf20/core/properties/Property.java
@@ -1,0 +1,122 @@
+package com.direwolf20.core.properties;
+
+import com.google.common.base.MoreObjects;
+import net.minecraft.nbt.ByteNBT;
+import net.minecraft.nbt.FloatNBT;
+import net.minecraft.nbt.INBT;
+import net.minecraft.nbt.IntNBT;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public final class Property<T> {
+    public static <T> Builder<T> builder(Class<T> type) {
+        return new Builder<>(type);
+    }
+
+    public static Builder<Integer> intBuilder() {
+        return builder(Integer.class).serializer(IntNBT::valueOf).deserializer(inbt -> ((IntNBT) inbt).getInt());
+    }
+
+    public static Builder<Boolean> booleanBuilder() {
+        return builder(Boolean.class).serializer(ByteNBT::valueOf).deserializer(inbt -> ((ByteNBT) inbt).getByte() != 0);
+    }
+
+    public static Builder<Float> floatBuilder() {
+        return builder(Float.class).serializer(FloatNBT::valueOf).deserializer(inbt -> ((FloatNBT) inbt).getFloat());
+    }
+
+    private final Class<T> type;
+    private final String name;
+    private final Function<T, INBT> serializer;
+    private final Function<INBT, T> deserializer;
+
+    private Property(Class<T> type, String name, Function<T, INBT> serializer, Function<INBT, T> deserializer) {
+        this.type = Objects.requireNonNull(type, "Cannot have a property without a type!");
+        this.name = Objects.requireNonNull(name, "Cannot have a property without a name!");
+        this.serializer = Objects.requireNonNull(serializer);
+        this.deserializer = Objects.requireNonNull(deserializer);
+    }
+
+    T cast(Object value) {
+        return type.cast(Objects.requireNonNull(value));
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public INBT serializeValue(Object value) {
+        return serialize(cast(value));
+    }
+
+    public INBT serialize(T value) {
+        return serializer.apply(value);
+    }
+
+    public T deserialize(INBT serialized) {
+        return deserializer.apply(serialized);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("type", type)
+                .add("name", name)
+                .toString();
+    }
+
+    public static final class Builder<T> {
+        private Class<T> type;
+        private String name;
+        private Function<T, INBT> serializer;
+        private Function<INBT, T> deserializer;
+
+        private Builder(Class<T> type) {
+            this.type = Objects.requireNonNull(type);
+        }
+
+        public Builder<T> name(ResourceLocation resourceLocation) {
+            return name(resourceLocation.toString());
+        }
+
+        public Builder<T> name(String modid, String path) {
+            return name(modid+":"+path);
+        }
+
+        public Builder<T> name(String name) {
+            this.name = Objects.requireNonNull(name);
+            return this;
+        }
+
+        public Builder<T> serializer(Function<T, INBT> serializer) {
+            this.serializer = Objects.requireNonNull(serializer);
+            return this;
+        }
+
+        public Builder<T> deserializer(Function<INBT, T> deserializer) {
+            this.deserializer = Objects.requireNonNull(deserializer);
+            return this;
+        }
+
+        public Property<T> build(ResourceLocation resourceLocation) {
+            name(resourceLocation);
+            return build();
+        }
+
+        public Property<T> build(String modid, String path) {
+            name(modid, path);
+            return build();
+        }
+
+        public Property<T> build(String name) {
+            name(name);
+            return build();
+        }
+
+        public Property<T> build() {
+            return new Property<>(type, name, serializer, deserializer);
+        }
+    }
+}

--- a/src/main/java/com/direwolf20/core/properties/Property.java
+++ b/src/main/java/com/direwolf20/core/properties/Property.java
@@ -21,6 +21,13 @@ import java.util.function.Function;
  * @param <T> The type of the values represented by this Property
  */
 public final class Property<T> {
+    private Property(Class<T> type, String name, Function<T, INBT> serializer, Function<INBT, T> deserializer) {
+        this.type = Objects.requireNonNull(type, "Cannot have a property without a type!");
+        this.name = Objects.requireNonNull(name, "Cannot have a property without a name!");
+        this.serializer = Objects.requireNonNull(serializer, "Cannot have a property without a serializer!");
+        this.deserializer = Objects.requireNonNull(deserializer, "Cannot have a property without a deserializer!");
+    }
+
     /**
      *
      * @param type The class of the values represented by the resulting {@link Property}
@@ -56,13 +63,6 @@ public final class Property<T> {
     private final String name;
     private final Function<T, INBT> serializer;
     private final Function<INBT, T> deserializer;
-
-    private Property(Class<T> type, String name, Function<T, INBT> serializer, Function<INBT, T> deserializer) {
-        this.type = Objects.requireNonNull(type, "Cannot have a property without a type!");
-        this.name = Objects.requireNonNull(name, "Cannot have a property without a name!");
-        this.serializer = Objects.requireNonNull(serializer, "Cannot have a property without a serializer!");
-        this.deserializer = Objects.requireNonNull(deserializer, "Cannot have a property without a deserializer!");
-    }
 
     T cast(Object value) {
         return type.cast(Objects.requireNonNull(value));

--- a/src/main/java/com/direwolf20/core/properties/PropertyContainer.java
+++ b/src/main/java/com/direwolf20/core/properties/PropertyContainer.java
@@ -1,10 +1,16 @@
 package com.direwolf20.core.properties;
 
-import com.direwolf20.core.DireCore20;
+import com.google.common.base.Preconditions;
 import net.minecraft.nbt.CompoundNBT;
 
 import java.util.*;
 
+/**
+ * The default {@link IPropertyContainer} which is created using a {@link Builder} to add the {@link Property Properties}
+ * represented by this container.
+ * @see IPropertyContainer
+ * @see Property
+ */
 public final class PropertyContainer implements IPropertyContainer{
     public static Builder builder() {
         return new Builder();
@@ -56,6 +62,10 @@ public final class PropertyContainer implements IPropertyContainer{
         }
     }
 
+    /**
+     * A simple build for the {@link PropertyContainer}. Notice that it enforces the container to only contain properties with
+     * distinc {@link Property#getName() names}, as per contract of {@link IPropertyContainer}!
+     */
     public static final class Builder {
         private Map<Property<?>, Object> properties;
         private Map<String, Property<?>> propertyByName;
@@ -65,12 +75,18 @@ public final class PropertyContainer implements IPropertyContainer{
             this.propertyByName = new HashMap<>();
         }
 
+        /**
+         * Sets the given Property to the given value / adds it with the given default, if not present.
+         * @param prop The Property to set/add
+         * @param value The value to set it to
+         * @param <T> The type of the value
+         * @return The Builder instance
+         * @throws IllegalArgumentException if a different Property, with the same name, was already in this Builder. (See the contract of {@link IPropertyContainer}.)
+         */
         public <T> Builder putProperty(Property<T> prop, T value) {
-            if (propertyByName.containsKey(prop.getName()) && propertyByName.get(prop.getName()) != prop) {
-                DireCore20.LOG.error("Caught ambiguous {} during PropertyContainer-Construction. " +
-                        "Each Property in the container must have a unique serialisation name! This will not be added to the container!", prop);
-                return this;
-            }
+            Preconditions.checkArgument(propertyByName.containsKey(prop.getName()) && propertyByName.get(prop.getName()) != prop,
+                    "Caught ambiguous %s during PropertyContainer-Construction. Each Property in the container must have a unique serialisation name! This will not be added to the container!"
+                    , prop);
             properties.put(prop, value);
             propertyByName.put(prop.getName(), prop);
             return this;

--- a/src/main/java/com/direwolf20/core/properties/PropertyContainer.java
+++ b/src/main/java/com/direwolf20/core/properties/PropertyContainer.java
@@ -18,10 +18,12 @@ public final class PropertyContainer implements IPropertyContainer{
 
     private final Map<Property<?>, Object> properties;
     private final Map<String, Property<?>> propertyByName;
+    private final Set<MutableProperty<?>> mutableProperties;
 
-    private PropertyContainer(Map<Property<?>, Object> properties, Map<String, Property<?>> propertyByName) {
+    private PropertyContainer(Map<Property<?>, Object> properties, Map<String, Property<?>> propertyByName, Set<MutableProperty<?>> mutableProperties) {
         this.properties = properties;
         this.propertyByName = propertyByName;
+        this.mutableProperties = mutableProperties;
     }
 
     @Override
@@ -31,9 +33,9 @@ public final class PropertyContainer implements IPropertyContainer{
     }
 
     @Override
-    public <T> boolean setProperty(Property<T> property, T value) {
-        if (properties.containsKey(property)) {
-            properties.put(property, value);
+    public <T> boolean setProperty(MutableProperty<T> property, T value) {
+        if (mutableProperties.contains(property)) {
+            properties.put(property.getProperty(), value);
             return true;
         }
         return false;
@@ -69,10 +71,12 @@ public final class PropertyContainer implements IPropertyContainer{
     public static final class Builder {
         private Map<Property<?>, Object> properties;
         private Map<String, Property<?>> propertyByName;
+        private final Set<MutableProperty<?>> mutableProperties;
 
         public Builder() {
             this.properties = new IdentityHashMap<>();
             this.propertyByName = new HashMap<>();
+            this.mutableProperties = Collections.newSetFromMap(new IdentityHashMap<>());
         }
 
         /**
@@ -92,9 +96,15 @@ public final class PropertyContainer implements IPropertyContainer{
             return this;
         }
 
+        public <T> Builder putProperty(MutableProperty<T> prop, T value) {
+            putProperty(prop.getProperty(), value);
+            mutableProperties.add(prop);
+            return this;
+        }
+
         public PropertyContainer build() {
             //do not convert to ImmutableMap here, as string key's are not well-behaved and this would therefore be slower
-            return new PropertyContainer(properties, propertyByName);
+            return new PropertyContainer(properties, propertyByName, mutableProperties);
         }
     }
 }

--- a/src/main/java/com/direwolf20/core/properties/PropertyContainer.java
+++ b/src/main/java/com/direwolf20/core/properties/PropertyContainer.java
@@ -12,6 +12,12 @@ import java.util.*;
  * @see Property
  */
 public final class PropertyContainer implements IPropertyContainer{
+    private PropertyContainer(Map<Property<?>, Object> properties, Map<String, Property<?>> propertyByName, Set<MutableProperty<?>> mutableProperties) {
+        this.properties = properties;
+        this.propertyByName = propertyByName;
+        this.mutableProperties = mutableProperties;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -20,11 +26,6 @@ public final class PropertyContainer implements IPropertyContainer{
     private final Map<String, Property<?>> propertyByName;
     private final Set<MutableProperty<?>> mutableProperties;
 
-    private PropertyContainer(Map<Property<?>, Object> properties, Map<String, Property<?>> propertyByName, Set<MutableProperty<?>> mutableProperties) {
-        this.properties = properties;
-        this.propertyByName = propertyByName;
-        this.mutableProperties = mutableProperties;
-    }
 
     @Override
     public <T> Optional<T> getProperty(Property<T> property) {

--- a/src/main/java/com/direwolf20/core/properties/PropertyContainer.java
+++ b/src/main/java/com/direwolf20/core/properties/PropertyContainer.java
@@ -1,0 +1,84 @@
+package com.direwolf20.core.properties;
+
+import com.direwolf20.core.DireCore20;
+import net.minecraft.nbt.CompoundNBT;
+
+import java.util.*;
+
+public final class PropertyContainer implements IPropertyContainer{
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final Map<Property<?>, Object> properties;
+    private final Map<String, Property<?>> propertyByName;
+
+    private PropertyContainer(Map<Property<?>, Object> properties, Map<String, Property<?>> propertyByName) {
+        this.properties = properties;
+        this.propertyByName = propertyByName;
+    }
+
+    @Override
+    public <T> Optional<T> getProperty(Property<T> property) {
+        return Optional.ofNullable(properties.get(property))
+                .map(property::cast);
+    }
+
+    @Override
+    public <T> boolean setProperty(Property<T> property, T value) {
+        if (properties.containsKey(property)) {
+            properties.put(property, value);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Set<Property<?>> listProperties() {
+        return Collections.unmodifiableSet(properties.keySet());
+    }
+
+    @Override
+    public CompoundNBT serializeNBT() {
+        CompoundNBT nbt = new CompoundNBT();
+        for (Map.Entry<Property<?>, Object> entry : properties.entrySet())
+            if (entry.getValue() != null)
+                nbt.put(entry.getKey().getName(), entry.getKey().serializeValue(entry.getValue()));
+        return nbt;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundNBT nbt) {
+        for (String key : nbt.keySet()) {
+            Property<?> prop = propertyByName.get(key);
+            if (prop != null) //This implicitly also checks whether the property is already in here...
+                properties.put(prop, prop.deserialize(nbt.get(key)));
+        }
+    }
+
+    public static final class Builder {
+        private Map<Property<?>, Object> properties;
+        private Map<String, Property<?>> propertyByName;
+
+        public Builder() {
+            this.properties = new IdentityHashMap<>();
+            this.propertyByName = new HashMap<>();
+        }
+
+        public <T> Builder putProperty(Property<T> prop, T value) {
+            if (propertyByName.containsKey(prop.getName()) && propertyByName.get(prop.getName()) != prop) {
+                DireCore20.LOG.error("Caught ambiguous {} during PropertyContainer-Construction. " +
+                        "Each Property in the container must have a unique serialisation name! This will not be added to the container!", prop);
+                return this;
+            }
+            properties.put(prop, value);
+            propertyByName.put(prop.getName(), prop);
+            return this;
+        }
+
+        public PropertyContainer build() {
+            //do not convert to ImmutableMap here, as string key's are not well-behaved and this would therefore be slower
+            return new PropertyContainer(properties, propertyByName);
+        }
+    }
+}


### PR DESCRIPTION
# Abstract
The idea of the Property System, is to describe mutable properties of Objects as a Property(Key)-Value pair and then use builtin serialisation mechanisms to handle the rest. Notice that is intentionally not meant as a System for attaching mutable values to Objects - the access can be limited, by limiting access to the Property instances (or to the MutableProperty instances, if only write-access is to be limited.)
# Example Usages
## Creating a Property
```java
//create a protected mutable Property
protected static final MutableProperty<Integer> RADIUS = Property.intBuilder()
    .buildMutable(BuildingGadgets.MOD_ID, "radius");
// get the read only variant
public static final Property<Integer> RADIUS_RO = RADIUS.getProperty();
//create a public boolean property
public static final Property<Boolean> BUILD_ATOP_RO = Property.booleanBuilder()
    .build(BuildingGadgets.MOD_ID, "build_atop")
```
It is of course also possible to create general properties by directly supplying type, serializer, deserializer and name, but I'll stick to 2 of my 3 built in ones for this example. Also it doesn't really make sense to make BUILD_ATOP Read-Only, as we do want to set it at some point - Notice that declaring a second MutableProperty with the same name will lead to a clash! If you want to have it mutable, you need to construct the mutable variant and get the immutable one from it.
## Reading a Property
```java
int radius = stack.getCapability(PropertyContainerCapability.PROPERTY_CONTAINER_CAPABILITY)
    .map(container -> container.getProperty(AbstractGadget.RADIUS))
    .orElse(Optional.of(0))
    .orElse(0);
```
Notice that AbstractGadget.RADIUS may be both a MutableProperty or a regular Property.
## Writing a Property
```java
stack.getCapability(PropertyContainerCapability.PROPERTY_CONTAINER_CAPABILITY)
    .ifPresent(container -> 
        container.setProperty(AbstractGadget.RADIUS, (container.getProperty(AbstractGadget.RADIUS)+1)%15))
```
Notice how the Property container, does not impose any bounds on the Property - these currently need to managed from outside. If this is necessary, we can easily add a Range and appropiate checks to it, as well as integration for Traits (In the above I only use 15, instead of a query for the Trait, as this would be too much for a simple example).
## Creating a PropertyContainer
```java
IPropertyContainer container = PropertyContainer.builder()
    .putProperty(AbstractGadget.RADIUS, 1)
    .putProperty(AbstractGadget.BUILD_ATOP, false)
    ...
    .build();
```
Notice that again it does not matter whether it is mutable or not, the Property can be added the same - and registering it as mutable is handeled behind the scences.